### PR TITLE
Fix duplicate API call in chat input

### DIFF
--- a/cozy-chat-bloom-main/src/components/ChatInput.tsx
+++ b/cozy-chat-bloom-main/src/components/ChatInput.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { useChatbot } from "@/contexts/ChatbotContext";
 import { Mic, MicOff, Send, Image, Paperclip, Smile } from "lucide-react";
-import { sendMessageToBackend } from "@/pages/Index";
 
 const ChatInput: React.FC = () => {
   const { sendMessage } = useChatbot();
@@ -11,23 +10,15 @@ const ChatInput: React.FC = () => {
   const [isVoiceInput, setIsVoiceInput] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleSendMessage = async () => {
+  const handleSendMessage = () => {
     if (message.trim() === "") return;
 
-    const userMessage = message;
+    sendMessage(message);
     setMessage("");
 
     // Reset textarea height
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
-    }
-
-    try {
-      const assistantReply = await sendMessageToBackend(userMessage);
-      sendMessage(userMessage, assistantReply);
-    } catch (error) {
-      console.error("Error getting reply from backend:", error);
-      sendMessage(userMessage, "Oops! Something went wrong.");
     }
   };
 


### PR DESCRIPTION
## Summary
- fix chat input to use context sendMessage directly
- avoid duplicate backend request

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, etc.)*
- `npm run build`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6846e718379883269ff05f2e114f0291